### PR TITLE
show views as badges with autofill preview query

### DIFF
--- a/components/query-input.tsx
+++ b/components/query-input.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react"
 import type { KeyboardEvent } from "react"
 
 import CommandEnter from "./CommandEnter"
+import { Badge } from "./ui/badge"
 
 interface QueryInputProps {
     onRunQuery: (query: string) => void
@@ -12,10 +13,18 @@ interface QueryInputProps {
     isLoading: boolean
     onCancelQuery: () => void
     isCancelling: boolean
+    views: string[]
 }
 
 const QueryInput: React.FC<QueryInputProps> = React.memo(
-    ({ onRunQuery, isRunning, isLoading, onCancelQuery, isCancelling }) => {
+    ({
+        onRunQuery,
+        isRunning,
+        views,
+        isLoading,
+        onCancelQuery,
+        isCancelling
+    }) => {
         const [query, setQuery] = useState<string>("")
 
         // run query if user hits cmd + enter
@@ -24,6 +33,12 @@ const QueryInput: React.FC<QueryInputProps> = React.memo(
                 e.preventDefault()
                 onRunQuery(query)
             }
+        }
+
+        // helpful auto-fill for preview query
+        const handleTableClick = (tableName: string) => {
+            const newQuery = `SELECT * FROM ${tableName} LIMIT 500`
+            setQuery(newQuery)
         }
 
         return (
@@ -37,6 +52,24 @@ const QueryInput: React.FC<QueryInputProps> = React.memo(
                     placeholder="Enter your SQL query here..."
                     className="w-full p-2 text-sm min-h-[120px] border border-slate-300 rounded resize-none mb-3"
                 />
+                {views.length > 0 && (
+                    <div className="mb-4">
+                        <label className="block text-xs font-medium text-slate-700 mb-2">
+                            Tables:
+                        </label>
+                        <div className="flex flex-wrap gap-1">
+                            {views.map((view) => (
+                                <Badge
+                                    className="text-xs cursor-pointer"
+                                    variant="secondary"
+                                    key={view}
+                                    onClick={() => handleTableClick(view)}>
+                                    {view}
+                                </Badge>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 {isRunning ? (
                     <Button
                         onClick={onCancelQuery}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils"
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
+
+const badgeVariants = cva(
+    "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+    {
+        variants: {
+            variant: {
+                default:
+                    "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+                secondary:
+                    "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                destructive:
+                    "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+                outline: "text-foreground"
+            }
+        },
+        defaultVariants: {
+            variant: "default"
+        }
+    }
+)
+
+export interface BadgeProps
+    extends React.HTMLAttributes<HTMLDivElement>,
+        VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+    return (
+        <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    )
+}
+
+export { Badge, badgeVariants }

--- a/services/DuckDBClient.ts
+++ b/services/DuckDBClient.ts
@@ -164,4 +164,19 @@ export class DuckDBClient {
             this.db = null
         }
     }
+
+    async getTables(): Promise<string[]> {
+        if (!this.db) {
+            throw new Error("Database not initialized")
+        }
+
+        const conn = await this.getConnection()
+        try {
+            const result = await conn.query("PRAGMA SHOW_TABLES")
+            return result.toArray().map((row) => row.name as string)
+        } finally {
+            await this.currentConnection.close()
+            this.currentConnection = null
+        }
+    }
 }

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -58,6 +58,7 @@ const Explorer = () => {
     )
     const rowsRef = useRef<RowData[]>([])
     const [viewsLoaded, setViewsLoaded] = useState<boolean>(false)
+    const [views, setViews] = useState<string[]>([])
 
     useEffect(() => {
         const fetchParquetInfo = async () => {
@@ -79,6 +80,10 @@ const Explorer = () => {
 
                 // load views
                 await client.loadConfig({ views })
+
+                // get views from duckdb
+                const successfulViews = await client.getTables()
+                setViews(successfulViews)
             } catch (err) {
                 console.error("Error fetching parquet info:", err)
                 setError("Error fetching dataset information")
@@ -190,6 +195,7 @@ const Explorer = () => {
                         isCancelling={isCancelling}
                         isLoading={loading || !viewsLoaded}
                         isRunning={isStreaming}
+                        views={views || []}
                         onCancelQuery={handleCancelQuery}
                     />
                     {error && (


### PR DESCRIPTION
<img width="480" alt="image" src="https://github.com/cfahlgren1/hf-data-explorer/assets/13546028/e07db9fc-3998-49d1-822a-d261aba3f68a">

### Clicking on Table Badge Autofill
<img width="472" alt="image" src="https://github.com/cfahlgren1/hf-data-explorer/assets/13546028/5d768596-69ea-4e91-acfd-02d7a6afbef1">


- show available views to query to the user
- autofill when clicked